### PR TITLE
Explicitly set version for qasync in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ uvicorn
 pyyaml
 gguf
 httpx
-qasync
+qasync==0.25.0
 fastapi # Explicitly add fastapi
 pytest
 pytest-asyncio


### PR DESCRIPTION
Newer versions of qasync greater than 0.25.0 break with the following error

```
File "llama-runner/main.py", line 107, in main
    asyncio.set_event_loop_policy(qasync.DefaultQEventLoopPolicy())
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'qasync' has no attribute 'DefaultQEventLoopPolicy'
```

Pinning to an older version resolves the issue. 
